### PR TITLE
Fix broken `can-i-deploy`pipeline stage

### DIFF
--- a/.github/workflows/trunk-pipeline.yml
+++ b/.github/workflows/trunk-pipeline.yml
@@ -40,9 +40,12 @@ jobs:
     # consumer about which of the consumer or the provider should be amended.
     runs-on: ubuntu-20.04
     steps:
-      - name: Check out code
+
+      - name: Check out consumer repo
         uses: actions/checkout@v2
         with:
+          repository: agilepathway/available-pets-consumer
+          path: './consumer'
           fetch-depth: '0'
 
       - name: Set consumer repo production commit output var
@@ -56,6 +59,7 @@ jobs:
 
       - name: Set contract repo commit output var
         id: set-contract-commit-output-var
+        path: './consumer'
         run: |
           CONSUMER_COMMIT=${{ steps.set-consumer-production-commit-output-var.outputs.commit }}
           CONTRACT_TAG=$(git describe --match "available-pets-consumer-contract*" --tags ${CONSUMER_COMMIT})


### PR DESCRIPTION
The pipeline was broken because we were erroneously looking for the
git tag with the contract commit in the provider repo, instead of the
consumer repo.