### PR TITLE
Store Portman test reports

### DIFF
--- a/.github/workflows/check-commit-message.yml
+++ b/.github/workflows/check-commit-message.yml
@@ -21,4 +21,4 @@ jobs:
         uses: mristin/opinionated-commit-message@v2.2.0
         with:
           allow-one-liners: 'true'
-          additional-verbs: 'export, parse, append, skip, store, retry, tidy, exit, deploy, verify, tag, amend'
+          additional-verbs: 'export, parse, append, skip, store, retry, tidy, exit, deploy, verify, store, tag, amend'

--- a/.github/workflows/pull-request-portman-tests.yml
+++ b/.github/workflows/pull-request-portman-tests.yml
@@ -38,3 +38,10 @@ jobs:
       - name: Verify implementation is in sync with API
         run: |
           portman --cliOptionsFile portman/portman-cli.json -b ${{ steps.review_app_status.outputs.review_app_url }}/v2
+
+      - name: Upload Portman test report
+        uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: portman-junit-report
+          path: newman/

--- a/newman/.gitignore
+++ b/newman/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/portman/portman-cli.json
+++ b/portman/portman-cli.json
@@ -5,5 +5,8 @@
   "portmanConfigFile": "portman/portman-config.json",
   "includeTests": true,
   "syncPostman": false,
-  "runNewman": true
+  "runNewman": true,
+  "newmanRunOptions": {
+    "reporters": ["cli", "junit"]
+  }
 }


### PR DESCRIPTION
For some reason trying to set a custom path for the junit test reports
(via [`reporter-junit-export`][1]) is not working, so we are keeping
the default reports directory of `./newman/`.

The reports are [stored as GitHub Actions artifacts][2].

[1]: https://github.com/postmanlabs/newman#junitxml-reporter
[2]: https://github.com/actions/upload-artifact