### PR TITLE
Publish Portman test reports inline in GitHub

### DIFF
--- a/.github/workflows/pull-request-portman-tests.yml
+++ b/.github/workflows/pull-request-portman-tests.yml
@@ -45,3 +45,10 @@ jobs:
         with:
           name: portman-junit-report
           path: newman/
+
+      - name: Publish Portman test results inline
+        uses: EnricoMi/publish-unit-test-result-action@v1
+        if: always()
+        with:
+          files: newman/*.xml
+          check_name: Portman Test Results


### PR DESCRIPTION
The Portman test results are now published in the GitHub Actions section
of the respective commit, via the [Publish Unit Test Results GitHub
Action][1]:

[1]: https://github.com/marketplace/actions/publish-unit-test-results