### PR TITLE
Change Newman test reports directory

### DIFF
--- a/.github/workflows/pull-request-portman-tests.yml
+++ b/.github/workflows/pull-request-portman-tests.yml
@@ -51,11 +51,11 @@ jobs:
         if: always()
         with:
           name: portman-junit-report
-          path: newman/
+          path: portman/output/newman/
 
       - name: Publish Portman test results inline
         uses: EnricoMi/publish-unit-test-result-action@v1
         if: always()
         with:
-          files: newman/*.xml
+          files: portman/output/newman/*.xml
           check_name: Portman Test Results

--- a/portman/output/newman/.gitignore
+++ b/portman/output/newman/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/portman/portman-cli.json
+++ b/portman/portman-cli.json
@@ -7,6 +7,11 @@
   "syncPostman": false,
   "runNewman": true,
   "newmanRunOptions": {
-    "reporters": ["cli", "junit"]
+    "reporters": ["cli", "junit"],
+    "reporter": {
+      "junit": {
+        "export": "portman/output/newman/"
+      }
+    }
   }
 }


### PR DESCRIPTION
This commit changes the Newman test report directory to be closer to the
other Portman output (i.e. the Postman collection).