### PR TITLE
Add Portman OpenAPI CLI report

### DIFF
--- a/.github/workflows/pull-request-portman-tests.yml
+++ b/.github/workflows/pull-request-portman-tests.yml
@@ -29,15 +29,24 @@ jobs:
       - name: Install Newman
         run: npm install -g newman
 
+      - name: Install Newman OpenAPI reporter
+        # https://github.com/NickHeap2/newman-reporter-openapi
+        run: npm install -g newman-reporter-openapi
+
       - name: Verify Review App status
         id: review_app_status
         uses: niteoweb/reviewapps-deploy-status@v1.4.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      # yamllint disable rule:line-length
       - name: Verify implementation is in sync with API
         run: |
-          portman --cliOptionsFile portman/portman-cli.json -b ${{ steps.review_app_status.outputs.review_app_url }}/v2
+          portman \
+            --cliOptionsFile portman/portman-cli.json \
+            -b ${{ steps.review_app_status.outputs.review_app_url }}/v2 \
+            --newmanRunOptions '{"reporters":["cli","junit","openapi"],"reporter":{"junit":{"export":"portman/output/newman/"},"openapi":{"spec":"openapi.yaml","serverUrl":"${{ steps.review_app_status.outputs.review_app_url }}/v2","reportstyle":"tall"}}}'
+      # yamllint enable rule:line-length
 
       - name: Upload generated Postman test collection
         uses: actions/upload-artifact@v2

--- a/portman/portman-cli.json
+++ b/portman/portman-cli.json
@@ -5,13 +5,5 @@
   "portmanConfigFile": "portman/portman-config.json",
   "includeTests": true,
   "syncPostman": false,
-  "runNewman": true,
-  "newmanRunOptions": {
-    "reporters": ["cli", "junit"],
-    "reporter": {
-      "junit": {
-        "export": "portman/output/newman/"
-      }
-    }
-  }
+  "runNewman": true
 }


### PR DESCRIPTION
This commit adds a very useful report to the CLI output when running
Portman.  This [Newman OpenAPI reporter][1] breaks down the test
coverage into the individual paths in the OpenAPI spec, making it clear
which pahts are not fully covered by the tests.

NB the reporter does not yet have functionality to output this report
in a file format (e.g. json or junit), but that is coming soon according
to the repo's README.  When that functionality arrives we can add it in
a future PR.

[1]: https://github.com/NickHeap2/newman-reporter-openapi