### PR TITLE
Remove unnecessary Java install from Portman CI

### DIFF
--- a/.github/workflows/pull-request-portman-tests.yml
+++ b/.github/workflows/pull-request-portman-tests.yml
@@ -17,12 +17,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2.3.4
 
-      - name: Set up Java
-        uses: actions/setup-java@v2
-        with:
-          distribution: 'temurin'
-          java-version: '17'
-
       - name: Install Portman
         run: npm install -g @apideck/portman
 


### PR DESCRIPTION
Portman tests our app as a black-box, so there is no need to install
Java.