### PR TITLE
Add content-type Portman tests

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -115,11 +115,6 @@ paths:
         '200':
           description: successful operation
           content:
-            application/xml:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/Pet'
             application/json:
               schema:
                 type: array
@@ -152,11 +147,6 @@ paths:
         '200':
           description: successful operation
           content:
-            application/xml:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/Pet'
             application/json:
               schema:
                 type: array
@@ -189,9 +179,6 @@ paths:
         '200':
           description: successful operation
           content:
-            application/xml:
-              schema:
-                $ref: '#/components/schemas/Pet'
             application/json:
               schema:
                 $ref: '#/components/schemas/Pet'
@@ -336,9 +323,6 @@ paths:
         '200':
           description: successful operation
           content:
-            application/xml:
-              schema:
-                $ref: '#/components/schemas/Order'
             application/json:
               schema:
                 $ref: '#/components/schemas/Order'
@@ -369,9 +353,6 @@ paths:
         '200':
           description: successful operation
           content:
-            application/xml:
-              schema:
-                $ref: '#/components/schemas/Order'
             application/json:
               schema:
                 $ref: '#/components/schemas/Order'
@@ -498,9 +479,6 @@ paths:
                 type: string
                 format: date-time
           content:
-            application/xml:
-              schema:
-                type: string
             application/json:
               schema:
                 type: string
@@ -534,9 +512,6 @@ paths:
         '200':
           description: successful operation
           content:
-            application/xml:
-              schema:
-                $ref: '#/components/schemas/User'
             application/json:
               schema:
                 $ref: '#/components/schemas/User'

--- a/portman/portman-config.json
+++ b/portman/portman-config.json
@@ -7,6 +7,12 @@
                 "statusSuccess": {
                     "enabled": true
                 }
+            },
+            {
+                "openApiOperation": "*::/*",
+                "contentType": {
+                    "enabled": true
+                }
             }
         ]
     },

--- a/src/main/java/uk/co/agilepathway/petstore/api/PetApiDelegate.java
+++ b/src/main/java/uk/co/agilepathway/petstore/api/PetApiDelegate.java
@@ -211,7 +211,7 @@ public interface PetApiDelegate {
                 }
             }
         });
-        return new ResponseEntity<>(HttpStatus.OK);
+        return new ResponseEntity<>(jsonContentType(), HttpStatus.OK);
 
     }
 

--- a/src/main/java/uk/co/agilepathway/petstore/api/UserApiDelegate.java
+++ b/src/main/java/uk/co/agilepathway/petstore/api/UserApiDelegate.java
@@ -123,7 +123,7 @@ public interface UserApiDelegate {
      */
     default ResponseEntity<String> loginUser(String username,
         String password) {
-        return new ResponseEntity<>(HttpStatus.OK);
+        return new ResponseEntity<>(jsonContentType(), HttpStatus.OK);
 
     }
 


### PR DESCRIPTION
We now check the content-type in the Portman tests that we automatically
generate.  See [the Portman contract tests documentation][1] for more
info.  To make the tests pass we have removed the unused xml
content-type in our OpenAPI spec when we encountered a failing test. It
is safe to do so as we know (via our consumer contract tests) that our
consumer only requires json as the content-type, not xml.

[1]: https://github.com/apideck-libraries/portman/tree/main/examples/testsuite-contract-tests#portman---contracttests-properties