### PR TITLE
Add Portman response time tests

### DIFF
--- a/portman/portman-config.json
+++ b/portman/portman-config.json
@@ -13,6 +13,13 @@
                 "contentType": {
                     "enabled": true
                 }
+            },
+            {
+                "openApiOperation": "*::/*",
+                "responseTime": {
+                    "enabled": true,
+                    "maxMs": 300
+                }
             }
         ]
     },


### PR DESCRIPTION
We now use Portman to check that our provider responds within a set
time.  See [Portman's response time documentation][1] for more info.

[1]: https://github.com/apideck-libraries/portman/tree/main/examples/testsuite-contract-tests#responsetime