### PR TITLE
Check OpenAPI required headers via Portman

### DIFF
--- a/portman/portman-config.json
+++ b/portman/portman-config.json
@@ -20,6 +20,12 @@
                     "enabled": true,
                     "maxMs": 300
                 }
+            },
+            {
+                "openApiOperation": "*::/*",
+                "headersPresent": {
+                    "enabled": true
+                }
             }
         ]
     },

--- a/src/main/java/uk/co/agilepathway/petstore/api/UserApiDelegate.java
+++ b/src/main/java/uk/co/agilepathway/petstore/api/UserApiDelegate.java
@@ -123,7 +123,10 @@ public interface UserApiDelegate {
      */
     default ResponseEntity<String> loginUser(String username,
         String password) {
-        return new ResponseEntity<>(jsonContentType(), HttpStatus.OK);
+        HttpHeaders headers = jsonContentType();
+        headers.add("X-Rate-Limit", "3");
+        headers.add("X-Expires-After", "2022-01-30T08:30:00Z");
+        return new ResponseEntity<>(headers, HttpStatus.OK);
 
     }
 


### PR DESCRIPTION
We now check that the headers specified in the OpenAPI spec are present
in the real implementation.  See the [Portman headers present
documentation][1] for more info.

[1]: https://github.com/apideck-libraries/portman/tree/main/examples/testsuite-contract-tests#headerspresent