### PR TITLE
Check JSON body in responses

### DIFF
--- a/portman/portman-config.json
+++ b/portman/portman-config.json
@@ -26,6 +26,12 @@
                 "headersPresent": {
                     "enabled": true
                 }
+            },
+            {
+                "openApiOperation": "*::/*",
+                "jsonBody": {
+                    "enabled": true
+                }
             }
         ]
     },

--- a/src/main/java/uk/co/agilepathway/petstore/api/PetApiDelegate.java
+++ b/src/main/java/uk/co/agilepathway/petstore/api/PetApiDelegate.java
@@ -211,7 +211,8 @@ public interface PetApiDelegate {
                 }
             }
         });
-        return new ResponseEntity<>(jsonContentType(), HttpStatus.OK);
+        ModelApiResponse responseBody = new ModelApiResponse().code(Integer.valueOf(4)).type("ok").message("magic!");
+        return new ResponseEntity<>(responseBody, jsonContentType(), HttpStatus.OK);
 
     }
 

--- a/src/main/java/uk/co/agilepathway/petstore/api/UserApiDelegate.java
+++ b/src/main/java/uk/co/agilepathway/petstore/api/UserApiDelegate.java
@@ -126,7 +126,7 @@ public interface UserApiDelegate {
         HttpHeaders headers = jsonContentType();
         headers.add("X-Rate-Limit", "3");
         headers.add("X-Expires-After", "2022-01-30T08:30:00Z");
-        return new ResponseEntity<>(headers, HttpStatus.OK);
+        return new ResponseEntity<String>("{}", headers, HttpStatus.OK);
 
     }
 


### PR DESCRIPTION
Now using Portman to validate if the response body is a JSON object,
based on the content-type defined in the OpenAPI response. See the
[Portman JSON body documentation][1] for more details.

[1]: https://github.com/apideck-libraries/portman/tree/main/examples/testsuite-contract-tests#jsonbody