### PR TITLE
Check response bodies respect OpenAPI JSON schema

### DIFF
--- a/portman/portman-config.json
+++ b/portman/portman-config.json
@@ -32,6 +32,12 @@
                 "jsonBody": {
                     "enabled": true
                 }
+            },
+            {
+                "openApiOperation": "*::/*",
+                "schemaValidation": {
+                    "enabled": true
+                }
             }
         ]
     },

--- a/src/main/java/uk/co/agilepathway/petstore/api/StoreApiDelegate.java
+++ b/src/main/java/uk/co/agilepathway/petstore/api/StoreApiDelegate.java
@@ -11,7 +11,10 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -84,9 +87,13 @@ public interface StoreApiDelegate {
                 }
             }
         });
-        Order order = new Order();
-        return new ResponseEntity<>(order, jsonContentType(), HttpStatus.OK);
+        return new ResponseEntity<>(exampleOrder(), jsonContentType(), HttpStatus.OK);
 
+    }
+
+    default Order exampleOrder() {
+        OffsetDateTime shipDate = new Date().toInstant().atOffset(ZoneOffset.UTC);
+        return new Order().id(1L).petId(1L).shipDate(shipDate).quantity(1).status(Order.StatusEnum.PLACED);
     }
 
     /**
@@ -112,8 +119,7 @@ public interface StoreApiDelegate {
                 }
             }
         });
-        Order order = new Order();
-        return new ResponseEntity<>(order, jsonContentType(), HttpStatus.OK);
+        return new ResponseEntity<>(exampleOrder(), jsonContentType(), HttpStatus.OK);
 
     }
 

--- a/src/main/java/uk/co/agilepathway/petstore/api/UserApiDelegate.java
+++ b/src/main/java/uk/co/agilepathway/petstore/api/UserApiDelegate.java
@@ -101,9 +101,12 @@ public interface UserApiDelegate {
                 }
             }
         });
-        User user = new User().firstName("Joe").lastName("Bloggs");
-        return new ResponseEntity<>(user, jsonContentType(), HttpStatus.OK);
+        return new ResponseEntity<>(exampleUser(), jsonContentType(), HttpStatus.OK);
+    }
 
+    default User exampleUser() {
+        return new User().firstName("Joe").lastName("Bloggs").email("joe@example.com").password("*******")
+                .phone("0780000001").userStatus(1).id(1L).username("joebloggs");
     }
 
     default HttpHeaders jsonContentType() {
@@ -126,7 +129,7 @@ public interface UserApiDelegate {
         HttpHeaders headers = jsonContentType();
         headers.add("X-Rate-Limit", "3");
         headers.add("X-Expires-After", "2022-01-30T08:30:00Z");
-        return new ResponseEntity<String>("{}", headers, HttpStatus.OK);
+        return new ResponseEntity<String>("\"success\"", headers, HttpStatus.OK);
 
     }
 


### PR DESCRIPTION
We now check if the response respects all the defined response
properties, allowed property types, required fields, allowed enums, ....
It does a full JSON schema verification, based on the OpenAPI response
properties.  See the [Portman schema validation documentation][1] for
more info.

[1]: https://github.com/apideck-libraries/portman/tree/main/examples/testsuite-contract-tests#schemavalidation