### PR TITLE
Add first Portman test that covers an unhappy path

### DIFF
--- a/portman/portman-config.json
+++ b/portman/portman-config.json
@@ -1,5 +1,12 @@
 {
     "version": 1.0,
+    "globals": {
+        "securityOverwrites": {
+            "bearer": {
+                "token": "YOUR_ACCESS_TOKEN"
+            }
+        }
+    },
     "tests": {
         "contractTests": [
             {
@@ -39,13 +46,36 @@
                     "enabled": true
                 }
             }
-        ]
-    },
-    "globals": {
-        "securityOverwrites": {
-            "bearer": {
-                "token": "YOUR_ACCESS_TOKEN"
+        ],
+        "variationTests": [
+            {
+                "openApiOperationId": "updatePet",
+                "openApiResponse": "400",
+                "variations": [
+                    {
+                        "name": "missingParams",
+                        "overwrites": [
+                            {
+                                "overwriteRequestBody": [
+                                    {
+                                        "key": "name",
+                                        "remove": true
+                                    }
+                                ]
+                            }
+                        ],
+                        "tests": {
+                            "contractTests": [
+                                {
+                                    "statusCode": {
+                                        "enabled": true
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ]
             }
-        }
+        ]
     }
 }

--- a/src/main/java/uk/co/agilepathway/petstore/api/PetApiDelegate.java
+++ b/src/main/java/uk/co/agilepathway/petstore/api/PetApiDelegate.java
@@ -170,6 +170,9 @@ public interface PetApiDelegate {
      * @see PetApi#updatePet
      */
     default ResponseEntity<Void> updatePet(Pet body) {
+        if ((body.getName() == null) || (body.getName().trim().isEmpty())) {
+            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+        }
         return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
 
     }


### PR DESCRIPTION
This commit adds a [Portman variation test][1] to cover just one of our
unhappy paths, as an example of how to do it (we can add more unhappy
path coverage in a future commit).  In our example here we use Portman
to remove the `name` property from the pet request body when trying to
update a Pet's details in the petstore, and verify that the service
responds with a `BAD_REQUEST` `400` response.

[1]: https://github.com/apideck-libraries/portman/tree/main/examples/testsuite-variation-tests