### PR TITLE
Add fuzzing unhappy path Portman tests

### DIFF
--- a/portman/portman-config.json
+++ b/portman/portman-config.json
@@ -75,6 +75,97 @@
                         }
                     }
                 ]
+            },
+            {
+                "openApiOperation": "*::/*",
+                "openApiResponse": "400",
+                "variations": [
+                    {
+                        "name": "Bad request",
+                        "fuzzing": [
+                            {
+                                "requestBody": [
+                                    {
+                                        "requiredFields": {
+                                            "enabled": true
+                                        },
+                                        "minimumNumberFields": {
+                                            "enabled": true
+                                        },
+                                        "maximumNumberFields": {
+                                            "enabled": true
+                                        },
+                                        "minLengthFields": {
+                                            "enabled": true
+                                        },
+                                        "maxLengthFields": {
+                                            "enabled": true
+                                        }
+                                    }
+                                ],
+                                "requestQueryParams": [
+                                    {
+                                        "requiredFields": {
+                                            "enabled": true
+                                        },
+                                        "minimumNumberFields": {
+                                            "enabled": true
+                                        },
+                                        "maximumNumberFields": {
+                                            "enabled": true
+                                        },
+                                        "minLengthFields": {
+                                            "enabled": true
+                                        },
+                                        "maxLengthFields": {
+                                            "enabled": true
+                                        }
+                                    }
+                                ],
+                                "requestHeaders": [
+                                    {
+                                        "requiredFields": {
+                                            "enabled": true
+                                        },
+                                        "minimumNumberFields": {
+                                            "enabled": true
+                                        },
+                                        "maximumNumberFields": {
+                                            "enabled": true
+                                        },
+                                        "minLengthFields": {
+                                            "enabled": true
+                                        },
+                                        "maxLengthFields": {
+                                            "enabled": true
+                                        }
+                                    }
+                                ]
+                            }
+                        ],
+                        "tests": {
+                            "contractTests": [
+                                {
+                                    "statusCode": {
+                                        "enabled": true
+                                    },
+                                    "contentType": {
+                                        "enabled": true
+                                    },
+                                    "jsonBody": {
+                                        "enabled": true
+                                    },
+                                    "schemaValidation": {
+                                        "enabled": true
+                                    },
+                                    "headersPresent": {
+                                        "enabled": true
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ]
             }
         ]
     }


### PR DESCRIPTION
Fuzzing [involves providing invalid, unexpected, or random data as
inputs to a computer program][1] (our REST API in our case).

[Portman provides fuzzing capabilities][2] to test our unhappy paths
(e.g. bad requests which generate a `BAD_REQUEST` `400` response) out
of the box.

See also [this GitHub Issue][3] which has a useful conversation about
how Portman's fuzzing works.

NB we've kept the "manual" unhappy path test which we created in the
previous commit 5e003ea, as it's a useful example, even though the
automatic fuzzing we've added here covers the same scenario
automatically.

[1]: https://en.wikipedia.org/wiki/Fuzzing
[2]: https://github.com/apideck-libraries/portman/tree/main/examples/testsuite-fuzzing-tests#openapi-fuzzing-for-variation-test-suite-generation
[3]: https://github.com/apideck-libraries/portman/issues/136