### PR TITLE
Update trunk consumer-driven tests to use Python

### DIFF
--- a/.github/workflows/trunk-pipeline.yml
+++ b/.github/workflows/trunk-pipeline.yml
@@ -75,11 +75,16 @@ jobs:
           path: './contract'
           ref: ${{ steps.set-contract-commit-output-var.outputs.contract-commit }}
 
-      - name: Set up Java
-        uses: actions/setup-java@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
         with:
-          distribution: 'temurin'
-          java-version: '17'
+          python-version: '3.x'
+
+      - name: Install Python dependencies
+        working-directory: ./contract
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
 
       - name: Install Gauge
         uses: getgauge/setup-gauge@master


### PR DESCRIPTION
The contract repo [now uses Python, not Java][1] for the consumer-driven
contract tests, so our CI provider pipeline needs to install Python when
running these tests.

[1]: agilepathway/available-pets-consumer-contract@0ed37e4